### PR TITLE
Change jax.tree_map to jax.tree_util.tree_map.

### DIFF
--- a/augmax/base.py
+++ b/augmax/base.py
@@ -52,9 +52,9 @@ class Transformation(ABC):
         if input_types is None:
           input_types = self.input_types
         if input_types is None:
-          input_types = jax.tree_map(lambda _: InputType.IMAGE, inputs)
+          input_types = jax.tree_util.tree_map(lambda _: InputType.IMAGE, inputs)
         try:
-          jax.tree_map(lambda _x, _y: None, inputs, self.input_types)
+          jax.tree_util.tree_map(lambda _x, _y: None, inputs, self.input_types)
         except ValueError:
             raise ValueError(f"PyTrees `inputs` and `input_types` are incompatible for Augmentation")
 
@@ -65,9 +65,9 @@ class Transformation(ABC):
         if input_types is None:
           input_types = self.input_types
         if input_types is None:
-          input_types = jax.tree_map(lambda _: InputType.IMAGE, inputs)
+          input_types = jax.tree_util.tree_map(lambda _: InputType.IMAGE, inputs)
         try:
-          jax.tree_map(lambda _x, _y: None, inputs, self.input_types)
+          jax.tree_util.tree_map(lambda _x, _y: None, inputs, self.input_types)
         except ValueError:
             raise ValueError(f"PyTrees `inputs` and `input_types` are incompatible for Augmentation")
         augmented = self.apply(rng, inputs, input_types, invert=True)

--- a/augmax/colorspace.py
+++ b/augmax/colorspace.py
@@ -40,7 +40,7 @@ class ColorspaceTransformation(Transformation):
             else:
                 return input
 
-        return jax.tree_map(transform_single, inputs, input_types)
+        return jax.tree_util.tree_map(transform_single, inputs, input_types)
 
 
 class ColorspaceChain(ColorspaceTransformation, BaseChain):

--- a/augmax/geometric.py
+++ b/augmax/geometric.py
@@ -98,7 +98,7 @@ class GeometricTransformation(Transformation):
             return np.array(inp.shape[:2])
           else:
             return np.array([])
-        shapes = jax.tree_map(extract_shape_if_imagelike, inputs, input_types)
+        shapes = jax.tree_util.tree_map(extract_shape_if_imagelike, inputs, input_types)
         for shape in jax.tree_util.tree_flatten(shapes)[0]:
           if len(shape) == 2:
             input_shapes.add(tuple(shape))
@@ -145,7 +145,7 @@ class GeometricTransformation(Transformation):
             else:
                 raise NotImplementedError(f"Cannot transform input of type {input_type} with {self.__class__.__name__}")
 
-        return jax.tree_map(transform_single, inputs, input_types)
+        return jax.tree_util.tree_map(transform_single, inputs, input_types)
 
     def output_shape(self, input_shape: Tuple[int, int]) -> Tuple[int, int]:
         return input_shape

--- a/augmax/imagelevel.py
+++ b/augmax/imagelevel.py
@@ -75,7 +75,7 @@ class GridShuffle(ImageLevelTransformation):
               return input
             else:
                 raise NotImplementedError(f"GridShuffle for {input_type} not yet implemented")
-        return jax.tree_map(transform_single, inputs, input_types)
+        return jax.tree_util.tree_map(transform_single, inputs, input_types)
 
 
 class _ConvolutionalBlur(ImageLevelTransformation):
@@ -108,7 +108,7 @@ class _ConvolutionalBlur(ImageLevelTransformation):
             else:
                 return input
 
-        return jax.tree_map(transform_single, inputs, input_types)
+        return jax.tree_util.tree_map(transform_single, inputs, input_types)
 
 
 class Blur(_ConvolutionalBlur):


### PR DESCRIPTION
The bare jax.tree_map was removed in jax v0.6.0, whereas jax.tree_util.tree_map is available in both old and new versions.